### PR TITLE
feat: add an api to directly submit form

### DIFF
--- a/plugin/src/api/FormFlowApi.ts
+++ b/plugin/src/api/FormFlowApi.ts
@@ -1,5 +1,6 @@
 import { App, Notice, TFile } from "obsidian";
 import { FormService } from "src/service/FormService";
+import { FormConfig } from "src/model/FormConfig";
 
 export class FormFlowApi {
 
@@ -12,6 +13,17 @@ export class FormFlowApi {
         const file = this.app.vault.getAbstractFileByPath(filePath);
         if (file instanceof TFile) {
             await formService.open(file, this.app);
+        } else {
+            new Notice(`Form File not found: ${filePath}`);
+        }
+    }
+	
+    async directlySubmitForm(filePath: string): Promise<void> {
+        const formService = new FormService();
+        const file = this.app.vault.getAbstractFileByPath(filePath);
+        if (file instanceof TFile) {
+            const form = await this.app.vault.readJson(file.path) as FormConfig;
+            await formService.submitDirectly(form, this.app);
         } else {
             new Notice(`Form File not found: ${filePath}`);
         }

--- a/plugin/src/api/FormFlowApi.ts
+++ b/plugin/src/api/FormFlowApi.ts
@@ -18,7 +18,7 @@ export class FormFlowApi {
         }
     }
 	
-    async directlySubmitForm(filePath: string): Promise<void> {
+    async submitFormFile(filePath: string): Promise<void> {
         const formService = new FormService();
         const file = this.app.vault.getAbstractFileByPath(filePath);
         if (file instanceof TFile) {


### PR DESCRIPTION
增加了一个 `api.directlySubmitForm("")` 函数。

利用它，可以通过脚本直接执行指定的表单文件，跳过弹窗配置部分。

运行示例：
```js
app.plugins.plugins['form-flow'].api.directlySubmitForm("_global/_plugin/Components/forms/form-摄入食物记录.cform")
```
