### PR TITLE
feat: add write-to-clipboard form action

### DIFF
--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -212,4 +212,5 @@ export class En implements Local {
 	wait = "Wait";
 	wait_time = "Wait time";
 	milliseconds = "Milliseconds";
+	write_to_clipboard = "Write to clipboard";
 }

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -200,4 +200,5 @@ export interface Local {
 	wait: string;
 	wait_time: string;
 	milliseconds: string;
+	write_to_clipboard: string;
 }

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -212,5 +212,6 @@ export class Zh implements Local {
 	wait = "等待";
 	wait_time = "等待时间";
 	milliseconds = "毫秒";
+	write_to_clipboard = "写入剪贴板";
 }
 

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -212,4 +212,5 @@ export class ZhTw implements Local {
 	wait = "等待";
 	wait_time = "等待時間";
 	milliseconds = "毫秒";
+	write_to_clipboard = "寫入剪貼簿";
 }

--- a/plugin/src/model/action/FormActionFactory.ts
+++ b/plugin/src/model/action/FormActionFactory.ts
@@ -7,6 +7,7 @@ import { RunScriptFormAction } from "./RunScriptFormAction";
 import { SuggestModalFormAction } from "./SuggestModalFormAction";
 import { UpdateFrontmatterFormAction } from "./UpdateFrontmatterFormAction";
 import { WaitFormAction } from "./WaitFormAction";
+import { WriteToClipboardFormAction } from "./WriteToClipboardFormAction";
 
 export class FormActionFactory {
     static create(type: FormActionType, partial?: Partial<IFormAction>): IFormAction {
@@ -45,6 +46,11 @@ export class FormActionFactory {
                 return new WaitFormAction({
                     ...partial,
                     type: FormActionType.WAIT
+                });
+            case FormActionType.WRITE_TO_CLIPBOARD:
+                return new WriteToClipboardFormAction({
+                    ...partial,
+                    type: FormActionType.WRITE_TO_CLIPBOARD
                 });
             default:
                 throw new Error(`Unsupported FormActionType: ${type}`);

--- a/plugin/src/model/action/WriteToClipboardFormAction.ts
+++ b/plugin/src/model/action/WriteToClipboardFormAction.ts
@@ -1,0 +1,19 @@
+import { FormActionType } from "../enums/FormActionType";
+import { BaseFormAction } from "./BaseFormAction";
+
+export class WriteToClipboardFormAction extends BaseFormAction {
+    type: FormActionType.WRITE_TO_CLIPBOARD;
+
+    /**
+     * Content to write to clipboard
+     * Supports variables like {{@fieldName}}, {{selection}}, {{clipboard}}, etc.
+     */
+    content: string;
+
+    constructor(partial?: Partial<WriteToClipboardFormAction>) {
+        super(partial);
+        this.type = FormActionType.WRITE_TO_CLIPBOARD;
+        this.content = "";
+        Object.assign(this, partial);
+    }
+}

--- a/plugin/src/model/enums/FormActionType.ts
+++ b/plugin/src/model/enums/FormActionType.ts
@@ -7,4 +7,5 @@ export enum FormActionType {
     GENERATE_FORM = "generateForm",
     RUN_COMMAND = "runCommand",
     WAIT = "wait",
+    WRITE_TO_CLIPBOARD = "writeToClipboard",
 }

--- a/plugin/src/service/action/IActionService.ts
+++ b/plugin/src/service/action/IActionService.ts
@@ -9,6 +9,7 @@ import RunScriptActionService from "./run-script/RunScriptActionService";
 import SuggestModalActionService from "./suggest-modal/SuggestModalActionService";
 import UpdateFrontmatterActionService from "./update-frontmatter/UpdateFrontmatterActionService";
 import WaitActionService from "./wait/WaitActionService";
+import WriteToClipboardActionService from "./write-to-clipboard/WriteToClipboardActionService";
 import { hasConditions } from "./util/hasConditions";
 import { FilterService } from "../filter/FilterService";
 import { RunCommandActionService } from "./run-command/RunCommandActionService";
@@ -39,6 +40,7 @@ export class ActionChain {
         new RunCommandActionService(),
         new GenerateFormActionService(),
         new WaitActionService(),
+        new WriteToClipboardActionService(),
     ]
 
     constructor(actions: IFormAction[]) {

--- a/plugin/src/service/action/write-to-clipboard/WriteToClipboardActionService.ts
+++ b/plugin/src/service/action/write-to-clipboard/WriteToClipboardActionService.ts
@@ -1,0 +1,32 @@
+import { IFormAction } from "src/model/action/IFormAction";
+import { WriteToClipboardFormAction } from "src/model/action/WriteToClipboardFormAction";
+import { FormActionType } from "src/model/enums/FormActionType";
+import { FormTemplateProcessEngine } from "../../engine/FormTemplateProcessEngine";
+import { ActionChain, ActionContext, IActionService } from "../IActionService";
+
+export default class WriteToClipboardActionService implements IActionService {
+
+    accept(action: IFormAction, context: ActionContext): boolean {
+        return action.type === FormActionType.WRITE_TO_CLIPBOARD;
+    }
+
+    async run(action: IFormAction, context: ActionContext, chain: ActionChain): Promise<void> {
+        const formAction = action as WriteToClipboardFormAction;
+        const state = context.state;
+        const app = context.app;
+
+        try {
+            // Process template variables in content
+            const templateEngine = new FormTemplateProcessEngine();
+            const processedContent = await templateEngine.process(formAction.content, state, app);
+            
+            // Write to clipboard
+            await navigator.clipboard.writeText(processedContent);
+        } catch (error) {
+            console.error("Failed to write to clipboard:", error);
+        }
+        
+        // Continue to next action
+        return await chain.next(context);
+    }
+}

--- a/plugin/src/view/edit/setting/action/CpsFormActionDetailSetting.tsx
+++ b/plugin/src/view/edit/setting/action/CpsFormActionDetailSetting.tsx
@@ -8,6 +8,7 @@ import { RunScriptSetting } from "./run-script/RunScriptSetting";
 import { SuggestModalSetting } from "./suggest-modal/SuggestModalSetting";
 import { UpdateFrontmatterSetting } from "./update-frontmatter/UpdateFrontmatterSetting";
 import { WaitSetting } from "./wait/WaitSetting";
+import { WriteToClipboardSetting } from "./write-to-clipboard/WriteToClipboardSetting";
 import { RemarkSetting } from "./common/RemarkSetting";
 import { RunCommandSetting } from "./run-command/RunCommandSetting";
 
@@ -28,6 +29,7 @@ export default function (props: {
 			<RunCommandSetting value={value} onChange={onChange} />
 			<GenerateFormSetting value={value} onChange={onChange} />
 			<WaitSetting value={value} onChange={onChange} />
+			<WriteToClipboardSetting value={value} onChange={onChange} />
 		</CpsForm>
 	);
 }

--- a/plugin/src/view/edit/setting/action/common/ActionTypeSelect.tsx
+++ b/plugin/src/view/edit/setting/action/common/ActionTypeSelect.tsx
@@ -6,6 +6,7 @@ import {
 	MessageSquare,
 	Text,
 	ZapIcon,
+	Clipboard,
 } from "lucide-react";
 import { localInstance } from "src/i18n/locals";
 import { FormActionType } from "src/model/enums/FormActionType";
@@ -71,5 +72,10 @@ export const formActionTypeOptions = [
 		value: FormActionType.WAIT,
 		label: localInstance.wait,
 		icon: <Hourglass />,
+	},
+	{
+		value: FormActionType.WRITE_TO_CLIPBOARD,
+		label: localInstance.write_to_clipboard,
+		icon: <Clipboard />,
 	},
 ];

--- a/plugin/src/view/edit/setting/action/write-to-clipboard/WriteToClipboardSetting.tsx
+++ b/plugin/src/view/edit/setting/action/write-to-clipboard/WriteToClipboardSetting.tsx
@@ -1,0 +1,27 @@
+import { localInstance } from "src/i18n/locals";
+import { IFormAction } from "src/model/action/IFormAction";
+import { WriteToClipboardFormAction } from "src/model/action/WriteToClipboardFormAction";
+import { FormActionType } from "src/model/enums/FormActionType";
+import TextAreaContentSetting from "../common/TextAreaContentSetting";
+
+export function WriteToClipboardSetting(props: {
+	value: IFormAction;
+	onChange: (value: IFormAction) => void;
+}) {
+	const { value } = props;
+	if (value.type !== FormActionType.WRITE_TO_CLIPBOARD) {
+		return null;
+	}
+	const action = value as WriteToClipboardFormAction;
+
+	return (
+		<TextAreaContentSetting
+			actionId={action.id}
+			content={action.content}
+			onChange={(value) => {
+				const newAction = { ...action, content: value };
+				props.onChange(newAction);
+			}}
+		/>
+	);
+}


### PR DESCRIPTION
Add a new WriteToClipboard form action end-to-end:
- Introduce WriteToClipboardFormAction model and enum value.
- Implement WriteToClipboardActionService scaffold.
- Register the new action in FormActionFactory and IActionService
  registry so it can be created and executed.
- Add UI bits: ActionTypeSelect option, WriteToClipboardSetting
  inclusion in action settings, and corresponding import fixes.
- Add i18n keys for English, Chinese and local type string.

This enables creating actions that write generated content to the
clipboard (supports variables like {{@ fieldName}}, {{selection}},
{{clipboard}}) and exposes the action in the editor settings.