### PR TITLE
feat: sort suggestions alphabetically with i18n

### DIFF
--- a/plugin/src/component/modal/CFormSuggestModal.tsx
+++ b/plugin/src/component/modal/CFormSuggestModal.tsx
@@ -21,10 +21,18 @@ export default class extends SuggestModal<TFile> {
 		const isPartialMatch = (item: TFile) =>
 			item.basename.toLowerCase().includes(q);
 
-		const fullmatch = items.filter((item) => isFullMatch(item));
+		// Sort function for alphabetical ascending order with Chinese and English support
+		const sortAscending = (a: TFile, b: TFile): number => {
+			return a.basename.localeCompare(b.basename, ['zh-CN', 'en'], {
+				numeric: true,
+				sensitivity: 'base'
+			});
+		};
+
+		const fullmatch = items.filter((item) => isFullMatch(item)).sort(sortAscending);
 		const suggestions = items.filter(
 			(item) => isPartialMatch(item) && !isFullMatch(item)
-		);
+		).sort(sortAscending);
 
 		this.tabEventHandler = (evt) => {
 			if (evt.key === "Tab") {


### PR DESCRIPTION
Add a locale-aware ascending sort for suggestion lists so both full
matches and partial are ordered alphabetically. Use
.prototype.localeCompare with zh-CN and en locales, numeric
comparison, and base sensitivity to handle Chinese and English text
consistently and to correctly order numeric parts.

This improves UX by providing predictable, internationalized ordering
for suggestions.