### PR TITLE
feat: add Move File action and related settings

### DIFF
--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -104,7 +104,6 @@ export class En implements Local {
 	insert_position = "Insert position";
 	insert_text = "Insert text";
 	internal_variables = "Internal variables";
-	is_current_file = "Is current file";
 	label = "Label";
 	less_than = "Less than";
 	less_than_or_equal = "Less than or equal";

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -104,6 +104,7 @@ export class En implements Local {
 	insert_position = "Insert position";
 	insert_text = "Insert text";
 	internal_variables = "Internal variables";
+	is_current_file = "Is current file";
 	label = "Label";
 	less_than = "Less than";
 	less_than_or_equal = "Less than or equal";

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -104,6 +104,7 @@ export class En implements Local {
 	insert_position = "Insert position";
 	insert_text = "Insert text";
 	internal_variables = "Internal variables";
+	is_current_file = "Is current file";
 	label = "Label";
 	less_than = "Less than";
 	less_than_or_equal = "Less than or equal";
@@ -111,6 +112,7 @@ export class En implements Local {
 	locate_position_in_file_list = "Locate position in file list";
 	mode = "Mode";
 	more = "More";
+	move_file = "Move file";
 	multiple = "Multiple select";
 	no_actions_configured = "No actions configured";
 	no_active_md_file = "No active Markdown file is open";
@@ -182,6 +184,7 @@ export class En implements Local {
 	suggest_modal = "Suggestion modal";
 	tag = "Tag";
 	target_file = "Target file";
+	target_folder = "Target folder";
 	template_file_not_exists = "Template file does not exist";
 	text_content = "Text content";
 	title = "Title";

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -117,6 +117,7 @@ export class En implements Local {
 	no_actions_configured = "No actions configured";
 	no_active_md_file = "No active Markdown file is open";
 	no_fields_for_form = "Form has no fields configured";
+	no_file_to_move = "No file to move";
 	no_matches_found_for = "No matches found for {0}";
 	no_options = "No options available";
 	no_script_find_in_folder = "No valid script files found in the script folder. Please add scripts to the \"{0}\" directory";
@@ -179,6 +180,7 @@ export class En implements Local {
 	source_code = "Code";
 	source_extension = "Extension";
 	source_file = "File";
+	source_file_not_found = "Source file not found";
 	source_text = "Text";
 	specified_date_time = "Specific date/time";
 	submit = "Submit";
@@ -188,6 +190,7 @@ export class En implements Local {
 	tag = "Tag";
 	target_file = "Target file";
 	target_folder = "Target folder";
+	target_path_exist = "Target path already exists";
 	template_file_not_exists = "Template file does not exist";
 	text_content = "Text content";
 	title = "Title";

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -190,7 +190,7 @@ export class En implements Local {
 	tag = "Tag";
 	target_file = "Target file";
 	target_folder = "Target folder";
-	target_path_exist = "Target path already exists";
+	move_failed_by_file_name_conflict = "Move failed, a file with the same name already exists in the target folder";
 	template_file_not_exists = "Template file does not exist";
 	text_content = "Text content";
 	title = "Title";

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -135,7 +135,10 @@ export class En implements Local {
 	open_page_in_split = "Split view";
 	open_page_in_tab = "New tab";
 	open_page_in_window = "New window";
+	operate_on_specified_file = "operate on specified file";
+	operate_on_current_file = "operate on current file";
 	operation_can_not_be_undone = "This operation cannot be undone. Please back up your data.";
+	operation_object = "Operation object";
 	operator_and = "And";
 	operator_condition = "Condition";
 	operator_or = "Or";

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -128,7 +128,10 @@ export interface Local {
 	open_page_in_split: string;
 	open_page_in_tab: string;
 	open_page_in_window: string;
+	operate_on_specified_file: string;
+	operate_on_current_file: string;
 	operation_can_not_be_undone: string;
+	operation_object: string;
 	operator_and: string;
 	operator_condition: string;
 	operator_or: string;

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -98,7 +98,6 @@ export interface Local {
 	insert_position: string;
 	insert_text: string;
 	internal_variables: string;
-	is_current_file: string;
 	label: string;
 	less_than_or_equal: string;
 	less_than: string;

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -111,6 +111,7 @@ export interface Local {
 	no_actions_configured: string;
 	no_active_md_file: string;
 	no_fields_for_form: string;
+	no_file_to_move: string;
 	no_matches_found_for: string;
 	no_options: string;
 	no_script_find_in_folder: string;
@@ -170,6 +171,7 @@ export interface Local {
 	source_code: string;
 	source_extension: string;
 	source_file: string;
+	source_file_not_found: string;
 	source_text: string;
 	source: string;
 	specified_date_time: string;
@@ -181,6 +183,7 @@ export interface Local {
 	template_file_not_exists: string;
 	text_content: string;
 	target_folder: string;
+	target_path_exist: string;
 	title: string;
 	to_internal_link: string;
 	top_below_title: string;

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -183,7 +183,7 @@ export interface Local {
 	template_file_not_exists: string;
 	text_content: string;
 	target_folder: string;
-	target_path_exist: string;
+	move_failed_by_file_name_conflict: string;
 	title: string;
 	to_internal_link: string;
 	top_below_title: string;

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -98,6 +98,7 @@ export interface Local {
 	insert_position: string;
 	insert_text: string;
 	internal_variables: string;
+	is_current_file: string;
 	label: string;
 	less_than_or_equal: string;
 	less_than: string;

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -98,6 +98,7 @@ export interface Local {
 	insert_position: string;
 	insert_text: string;
 	internal_variables: string;
+	is_current_file: string;
 	label: string;
 	less_than_or_equal: string;
 	less_than: string;
@@ -105,6 +106,7 @@ export interface Local {
 	locate_position_in_file_list: string;
 	mode: string;
 	more: string;
+	move_file: string;
 	multiple: string;
 	no_actions_configured: string;
 	no_active_md_file: string;
@@ -175,6 +177,7 @@ export interface Local {
 	target_file: string;
 	template_file_not_exists: string;
 	text_content: string;
+	target_folder: string;
 	title: string;
 	to_internal_link: string;
 	top_below_title: string;

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -104,6 +104,7 @@ export class Zh implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文本";
 	internal_variables = "内置变量";
+	is_current_file = "是否当前文件";
 	label = "名称";
 	less_than = "小于";
 	less_than_or_equal = "小于等于";

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -190,7 +190,7 @@ export class Zh implements Local {
 	tag = "标签";
 	target_file = "目标文件";
 	target_folder = "目标文件夹";
-	target_path_exist = "目标路径已存在";
+	move_failed_by_file_name_conflict = "移动失败，目录下已存在同名文件";
 	template_file_not_exists = "模板文件不存在";
 	text_content = "文本内容";
 	title = "标题";

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -135,7 +135,10 @@ export class Zh implements Local {
 	open_page_in_split = "分屏";
 	open_page_in_tab = "新标签页";
 	open_page_in_window = "新窗口";
+	operate_on_specified_file = "操作指定文件";
+	operate_on_current_file = "操作当前文件";
 	operation_can_not_be_undone = "该操作不可撤销，请做好备份";
+	operation_object = "操作对象";
 	operator_and = "并且";
 	operator_condition = "条件";
 	operator_or = "或者";

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -104,6 +104,7 @@ export class Zh implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文本";
 	internal_variables = "内置变量";
+	is_current_file = "是否当前文件";
 	label = "名称";
 	less_than = "小于";
 	less_than_or_equal = "小于等于";
@@ -111,6 +112,7 @@ export class Zh implements Local {
 	locate_position_in_file_list = "在文件目录中定位";
 	mode = "模式";
 	more = "更多";
+	move_file = "移动文件";
 	multiple = "多选";
 	no_actions_configured = "没有配置任何操作";
 	no_active_md_file = "当前没有打开的 Markdown 文件";
@@ -182,6 +184,7 @@ export class Zh implements Local {
 	suggest_modal = "列表窗口";
 	tag = "标签";
 	target_file = "目标文件";
+	target_folder = "目标文件夹";
 	template_file_not_exists = "模板文件不存在";
 	text_content = "文本内容";
 	title = "标题";

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -104,7 +104,6 @@ export class Zh implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文本";
 	internal_variables = "内置变量";
-	is_current_file = "是否当前文件";
 	label = "名称";
 	less_than = "小于";
 	less_than_or_equal = "小于等于";

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -117,6 +117,7 @@ export class Zh implements Local {
 	no_actions_configured = "没有配置任何操作";
 	no_active_md_file = "当前没有打开的 Markdown 文件";
 	no_fields_for_form = "表单没有配置字段";
+	no_file_to_move = "没有要移动的文件";
 	no_matches_found_for = "没有找到匹配项 {0}";
 	no_options = "没有选项";
 	no_script_find_in_folder = "脚本目录下没有合法的脚本文件，请添加脚本到目录 \"{0}\" 下";
@@ -179,6 +180,7 @@ export class Zh implements Local {
 	source_code = "代码";
 	source_extension = "扩展";
 	source_file = "文件";
+	source_file_not_found = "文件未找到";
 	source_text = "文本";
 	specified_date_time = "具体时间";
 	submit = "提交";
@@ -188,6 +190,7 @@ export class Zh implements Local {
 	tag = "标签";
 	target_file = "目标文件";
 	target_folder = "目标文件夹";
+	target_path_exist = "目标路径已存在";
 	template_file_not_exists = "模板文件不存在";
 	text_content = "文本内容";
 	title = "标题";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -190,7 +190,7 @@ export class ZhTw implements Local {
 	tag = "標籤";
 	target_file = "目標檔案";
 	target_folder= "目標目錄";
-	target_path_exist = "目標路徑已存在";
+	move_failed_by_file_name_conflict = "移動失敗，目標目錄已存在同名檔案";
 	template_file_not_exists = "模板檔案不存在";
 	text_content = "文字內容";
 	title = "標題";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -104,6 +104,7 @@ export class ZhTw implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文字";
 	internal_variables = "內建變數";
+	is_current_file = "是否目前檔案";
 	label = "名稱";
 	less_than = "小於";
 	less_than_or_equal = "小於等於";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -104,7 +104,6 @@ export class ZhTw implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文字";
 	internal_variables = "內建變數";
-	is_current_file = "是否目前檔案";
 	label = "名稱";
 	less_than = "小於";
 	less_than_or_equal = "小於等於";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -117,6 +117,7 @@ export class ZhTw implements Local {
 	no_actions_configured = "沒有配置任何操作";
 	no_active_md_file = "目前沒有打開的 Markdown 檔案";
 	no_fields_for_form = "表單沒有配置欄位";
+	no_file_to_move = "沒有要移動的檔案";
 	no_matches_found_for = "沒有找到匹配項 {0}";
 	no_options = "沒有選項";
 	no_script_find_in_folder = "腳本目錄下沒有合法的腳本檔案，請添加腳本到目錄 \"{0}\" 下";
@@ -179,6 +180,7 @@ export class ZhTw implements Local {
 	source_code = "代碼";
 	source_extension = "擴展";
 	source_file = "檔案";
+	source_file_not_found = "檔案未找到";
 	source_text = "文字";
 	specified_date_time = "具體時間";
 	submit = "提交";
@@ -188,6 +190,7 @@ export class ZhTw implements Local {
 	tag = "標籤";
 	target_file = "目標檔案";
 	target_folder= "目標目錄";
+	target_path_exist = "目標路徑已存在";
 	template_file_not_exists = "模板檔案不存在";
 	text_content = "文字內容";
 	title = "標題";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -135,7 +135,10 @@ export class ZhTw implements Local {
 	open_page_in_split = "分屏";
 	open_page_in_tab = "新標籤頁";
 	open_page_in_window = "新視窗";
+	operate_on_specified_file = "操作指定檔案";
+	operate_on_current_file = "操作目前檔案";
 	operation_can_not_be_undone = "該操作不可撤銷，請做好備份";
+	operation_object = "操作对象";
 	operator_and = "並且";
 	operator_condition = "條件";
 	operator_or = "或者";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -104,6 +104,7 @@ export class ZhTw implements Local {
 	insert_position = "插入位置";
 	insert_text = "插入文字";
 	internal_variables = "內建變數";
+	is_current_file = "是否目前檔案";
 	label = "名稱";
 	less_than = "小於";
 	less_than_or_equal = "小於等於";
@@ -111,6 +112,7 @@ export class ZhTw implements Local {
 	locate_position_in_file_list = "在檔案目錄中定位";
 	mode = "模式";
 	more = "更多";
+	move_file= "移動檔案";
 	multiple = "多選";
 	no_actions_configured = "沒有配置任何操作";
 	no_active_md_file = "目前沒有打開的 Markdown 檔案";
@@ -182,6 +184,7 @@ export class ZhTw implements Local {
 	suggest_modal = "列表視窗";
 	tag = "標籤";
 	target_file = "目標檔案";
+	target_folder= "目標目錄";
 	template_file_not_exists = "模板檔案不存在";
 	text_content = "文字內容";
 	title = "標題";

--- a/plugin/src/model/action/FormActionFactory.ts
+++ b/plugin/src/model/action/FormActionFactory.ts
@@ -8,6 +8,7 @@ import { SuggestModalFormAction } from "./SuggestModalFormAction";
 import { UpdateFrontmatterFormAction } from "./UpdateFrontmatterFormAction";
 import { WaitFormAction } from "./WaitFormAction";
 import { WriteToClipboardFormAction } from "./WriteToClipboardFormAction";
+import { MoveFileFormAction } from "./MoveFileFormAction";
 
 export class FormActionFactory {
     static create(type: FormActionType, partial?: Partial<IFormAction>): IFormAction {
@@ -51,6 +52,11 @@ export class FormActionFactory {
                 return new WriteToClipboardFormAction({
                     ...partial,
                     type: FormActionType.WRITE_TO_CLIPBOARD
+                });
+            case FormActionType.MOVE_FILE:
+                return new MoveFileFormAction({
+                    ...partial,
+                    type: FormActionType.MOVE_FILE
                 });
             default:
                 throw new Error(`Unsupported FormActionType: ${type}`);

--- a/plugin/src/model/action/MoveFileFormAction.ts
+++ b/plugin/src/model/action/MoveFileFormAction.ts
@@ -1,17 +1,17 @@
 import { FormActionType } from "../enums/FormActionType";
-import { FileBaseFormAction } from "./FileBaseFormAction";
-import { TargetFileType } from "../enums/TargetFileType";
+import { BaseFormAction } from "./BaseFormAction";
 
-
-export class MoveFileFormAction extends FileBaseFormAction {
+export class MoveFileFormAction extends BaseFormAction {
     type: FormActionType.MOVE_FILE;
-    targetFileType: TargetFileType;
+    isCurrentFile: boolean = true;
+    file: string;
     targetFolder: string;
 
     constructor(partial?: Partial<MoveFileFormAction>) {
         super(partial);
         this.type = FormActionType.MOVE_FILE;
-        this.targetFileType = TargetFileType.SPECIFIED_FILE;
+        this.isCurrentFile = true;
+        this.file = "";
         this.targetFolder = "";
         Object.assign(this, partial);
     }

--- a/plugin/src/model/action/MoveFileFormAction.ts
+++ b/plugin/src/model/action/MoveFileFormAction.ts
@@ -1,18 +1,19 @@
 import { FormActionType } from "../enums/FormActionType";
-import { BaseFormAction } from "./BaseFormAction";
+import { TargetFileType } from "../enums/TargetFileType";
+import { FileBaseFormAction } from "./FileBaseFormAction";
 
-export class MoveFileFormAction extends BaseFormAction {
+export class MoveFileFormAction extends FileBaseFormAction {
     type: FormActionType.MOVE_FILE;
-    isCurrentFile: boolean = true;
-    file: string;
-    targetFolder: string;
+    
+    targetFileType: TargetFileType;
+    
+    moveTargetFolder: string;
 
     constructor(partial?: Partial<MoveFileFormAction>) {
         super(partial);
         this.type = FormActionType.MOVE_FILE;
-        this.isCurrentFile = true;
-        this.file = "";
-        this.targetFolder = "";
+        this.targetFileType = TargetFileType.CURRENT_FILE;
+        this.moveTargetFolder = "";
         Object.assign(this, partial);
     }
 }

--- a/plugin/src/model/action/MoveFileFormAction.ts
+++ b/plugin/src/model/action/MoveFileFormAction.ts
@@ -1,0 +1,18 @@
+import { FormActionType } from "../enums/FormActionType";
+import { BaseFormAction } from "./BaseFormAction";
+
+export class MoveFileFormAction extends BaseFormAction {
+    type: FormActionType.MOVE_FILE;
+    isCurrentFile: boolean = true;
+    file: string;
+    targetFolder: string;
+
+    constructor(partial?: Partial<MoveFileFormAction>) {
+        super(partial);
+        this.type = FormActionType.MOVE_FILE;
+        this.isCurrentFile = true;
+        this.file = "";
+        this.targetFolder = "";
+        Object.assign(this, partial);
+    }
+}

--- a/plugin/src/model/action/MoveFileFormAction.ts
+++ b/plugin/src/model/action/MoveFileFormAction.ts
@@ -1,17 +1,17 @@
 import { FormActionType } from "../enums/FormActionType";
-import { BaseFormAction } from "./BaseFormAction";
+import { FileBaseFormAction } from "./FileBaseFormAction";
+import { TargetFileType } from "../enums/TargetFileType";
 
-export class MoveFileFormAction extends BaseFormAction {
+
+export class MoveFileFormAction extends FileBaseFormAction {
     type: FormActionType.MOVE_FILE;
-    isCurrentFile: boolean = true;
-    file: string;
+    targetFileType: TargetFileType;
     targetFolder: string;
 
     constructor(partial?: Partial<MoveFileFormAction>) {
         super(partial);
         this.type = FormActionType.MOVE_FILE;
-        this.isCurrentFile = true;
-        this.file = "";
+        this.targetFileType = TargetFileType.SPECIFIED_FILE;
         this.targetFolder = "";
         Object.assign(this, partial);
     }

--- a/plugin/src/model/enums/FormActionType.ts
+++ b/plugin/src/model/enums/FormActionType.ts
@@ -8,4 +8,5 @@ export enum FormActionType {
     RUN_COMMAND = "runCommand",
     WAIT = "wait",
     WRITE_TO_CLIPBOARD = "writeToClipboard",
+    MOVE_FILE = "moveFile",
 }

--- a/plugin/src/service/action/IActionService.ts
+++ b/plugin/src/service/action/IActionService.ts
@@ -10,6 +10,7 @@ import SuggestModalActionService from "./suggest-modal/SuggestModalActionService
 import UpdateFrontmatterActionService from "./update-frontmatter/UpdateFrontmatterActionService";
 import WaitActionService from "./wait/WaitActionService";
 import WriteToClipboardActionService from "./write-to-clipboard/WriteToClipboardActionService";
+import MoveFileActionService from "./move-file/MoveFileActionService";
 import { hasConditions } from "./util/hasConditions";
 import { FilterService } from "../filter/FilterService";
 import { RunCommandActionService } from "./run-command/RunCommandActionService";
@@ -41,6 +42,7 @@ export class ActionChain {
         new GenerateFormActionService(),
         new WaitActionService(),
         new WriteToClipboardActionService(),
+        new MoveFileActionService(),
     ]
 
     constructor(actions: IFormAction[]) {

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -1,3 +1,4 @@
+import { TFile } from "obsidian";
 import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { IFormAction } from "src/model/action/IFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
@@ -5,6 +6,7 @@ import { ActionChain, ActionContext, IActionService } from "../IActionService";
 import { getFilePathFromAction } from "../util/getFilePathFromAction";
 import { normalizePath } from "obsidian";
 import { FormTemplateProcessEngine } from "src/service/engine/FormTemplateProcessEngine";
+import { localInstance } from "src/i18n/locals";
 
 export default class MoveFileActionService implements IActionService {
 
@@ -22,13 +24,13 @@ export default class MoveFileActionService implements IActionService {
             
             if (!fileToMovePath) {
                 console.error('[MoveFileActionService] No file to move');
-                return;
+                throw new Error(localInstance.no_file_to_move);
             }
 
             const sourceFile = app.vault.getAbstractFileByPath(fileToMovePath);
             if (!sourceFile) {
                 console.error('[MoveFileActionService] Source file not found:', fileToMovePath);
-                return;
+                throw new Error(localInstance.source_file_not_found);
             }
 
             // Build target path
@@ -36,11 +38,16 @@ export default class MoveFileActionService implements IActionService {
             const fileName = fileToMovePath.split('/').pop();
             const moveTargetFolder = await engine.process(formAction.moveTargetFolder, context.state, app);
             const targetPath = normalizePath(moveTargetFolder + '/' + fileName);
+            const file = app.vault.getAbstractFileByPath(targetPath);
+            if (file) {
+                console.error('[MoveFileActionService] Target path exist:', targetPath);
+                throw new Error(localInstance.target_path_exist);
+            }
             await app.fileManager.renameFile(sourceFile, targetPath);
             
         } catch (error) {
             console.error('[MoveFileActionService] Error moving file:', error);
-            return;
+            throw new Error(error);
         }
             
         // do next

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -1,0 +1,34 @@
+import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
+import { IFormAction } from "src/model/action/IFormAction";
+import { FormActionType } from "src/model/enums/FormActionType";
+import { ActionChain, ActionContext, IActionService } from "../IActionService";
+
+export default class MoveFileActionService implements IActionService {
+
+    accept(action: IFormAction, context: ActionContext): boolean {
+        return action.type === FormActionType.MOVE_FILE;
+    }
+
+    async run(action: IFormAction, context: ActionContext, chain: ActionChain) {
+        const formAction = action as MoveFileFormAction;
+        const app = context.app;
+        const activeFile = app.workspace.getActiveFile();
+
+        const fileToMovePath = formAction.isCurrentFile
+            ? (activeFile?.path ?? '')
+            : formAction.file;
+            
+        if (!fileToMovePath) {
+            console.error('[MoveFileActionService] No file to move');
+            return;
+        }
+        app.fileManager.renameFile(
+            context.app.vault.getAbstractFileByPath(fileToMovePath)!,
+            formAction.targetFolder+'/'+fileToMovePath.split('/').pop()
+        );
+            
+        // do next
+        await chain.next(context);
+    }
+
+}   

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -21,7 +21,6 @@ export default class MoveFileActionService implements IActionService {
         try {
             // Use the unified file path resolution utility
             const fileToMovePath = await getFilePathFromAction(formAction, context);
-            
             if (!fileToMovePath) {
                 console.error('[MoveFileActionService] No file to move');
                 throw new Error(localInstance.no_file_to_move);
@@ -41,15 +40,13 @@ export default class MoveFileActionService implements IActionService {
             const file = app.vault.getAbstractFileByPath(targetPath);
             if (file) {
                 console.error('[MoveFileActionService] Target path exist:', targetPath);
-                throw new Error(localInstance.target_path_exist);
+                throw new Error(localInstance.move_failed_by_file_name_conflict);
             }
             await app.fileManager.renameFile(sourceFile, targetPath);
-            
         } catch (error) {
             console.error('[MoveFileActionService] Error moving file:', error);
             throw new Error(error);
         }
-            
         // do next
         await chain.next(context);
     }

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -4,6 +4,7 @@ import { FormActionType } from "src/model/enums/FormActionType";
 import { ActionChain, ActionContext, IActionService } from "../IActionService";
 import { getFilePathFromAction } from "../util/getFilePathFromAction";
 import { normalizePath } from "obsidian";
+import { FormTemplateProcessEngine } from "src/service/engine/FormTemplateProcessEngine";
 
 export default class MoveFileActionService implements IActionService {
 
@@ -31,9 +32,10 @@ export default class MoveFileActionService implements IActionService {
             }
 
             // Build target path
+            const engine = new FormTemplateProcessEngine();
             const fileName = fileToMovePath.split('/').pop();
-            const targetPath = normalizePath(formAction.moveTargetFolder + '/' + fileName);
-            
+            const moveTargetFolder = await engine.process(formAction.moveTargetFolder, context.state, app);
+            const targetPath = normalizePath(moveTargetFolder + '/' + fileName);
             await app.fileManager.renameFile(sourceFile, targetPath);
             
         } catch (error) {

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -2,6 +2,8 @@ import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { IFormAction } from "src/model/action/IFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import { ActionChain, ActionContext, IActionService } from "../IActionService";
+import { getFilePathFromAction } from "../util/getFilePathFromAction";
+import { normalizePath } from "obsidian";
 
 export default class MoveFileActionService implements IActionService {
 
@@ -12,20 +14,32 @@ export default class MoveFileActionService implements IActionService {
     async run(action: IFormAction, context: ActionContext, chain: ActionChain) {
         const formAction = action as MoveFileFormAction;
         const app = context.app;
-        const activeFile = app.workspace.getActiveFile();
 
-        const fileToMovePath = formAction.isCurrentFile
-            ? (activeFile?.path ?? '')
-            : formAction.file;
+        try {
+            // Use the unified file path resolution utility
+            const fileToMovePath = await getFilePathFromAction(formAction, context);
             
-        if (!fileToMovePath) {
-            console.error('[MoveFileActionService] No file to move');
+            if (!fileToMovePath) {
+                console.error('[MoveFileActionService] No file to move');
+                return;
+            }
+
+            const sourceFile = app.vault.getAbstractFileByPath(fileToMovePath);
+            if (!sourceFile) {
+                console.error('[MoveFileActionService] Source file not found:', fileToMovePath);
+                return;
+            }
+
+            // Build target path
+            const fileName = fileToMovePath.split('/').pop();
+            const targetPath = normalizePath(formAction.moveTargetFolder + '/' + fileName);
+            
+            await app.fileManager.renameFile(sourceFile, targetPath);
+            
+        } catch (error) {
+            console.error('[MoveFileActionService] Error moving file:', error);
             return;
         }
-        app.fileManager.renameFile(
-            context.app.vault.getAbstractFileByPath(fileToMovePath)!,
-            formAction.targetFolder+'/'+fileToMovePath.split('/').pop()
-        );
             
         // do next
         await chain.next(context);

--- a/plugin/src/service/action/move-file/MoveFileActionService.ts
+++ b/plugin/src/service/action/move-file/MoveFileActionService.ts
@@ -1,8 +1,6 @@
 import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { IFormAction } from "src/model/action/IFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
-import { getFilePathFromAction } from "../util/getFilePathFromAction";
-import { createFileFromActionIfNotExists } from "../util/createFileFromActionIfNotExists";
 import { ActionChain, ActionContext, IActionService } from "../IActionService";
 
 export default class MoveFileActionService implements IActionService {
@@ -13,17 +11,22 @@ export default class MoveFileActionService implements IActionService {
 
     async run(action: IFormAction, context: ActionContext, chain: ActionChain) {
         const formAction = action as MoveFileFormAction;
-        const filePath = await getFilePathFromAction(formAction, context);
-        if (!filePath) {
-            console.log('MoveFileActionService', 'filePath is null');
+        const app = context.app;
+        const activeFile = app.workspace.getActiveFile();
+
+        const fileToMovePath = formAction.isCurrentFile
+            ? (activeFile?.path ?? '')
+            : formAction.file;
+            
+        if (!fileToMovePath) {
+            console.error('[MoveFileActionService] No file to move');
             return;
         }
-        const file = await createFileFromActionIfNotExists(filePath, formAction, context);
-
-        context.app.fileManager.renameFile(
-            file,
-            formAction.targetFolder+'/'+filePath.split('/').pop()
-        );        
+        app.fileManager.renameFile(
+            context.app.vault.getAbstractFileByPath(fileToMovePath)!,
+            formAction.targetFolder+'/'+fileToMovePath.split('/').pop()
+        );
+            
         // do next
         await chain.next(context);
     }

--- a/plugin/src/service/action/util/createFileFromActionIfNotExists.ts
+++ b/plugin/src/service/action/util/createFileFromActionIfNotExists.ts
@@ -4,19 +4,23 @@ import { ActionContext } from "../IActionService";
 import { localInstance } from "src/i18n/locals";
 import { InsertTextFormAction } from "src/model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
+import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
+import { FormActionType } from "src/model/enums/FormActionType";
 import { createFileByText } from "src/utils/createFileByText";
 import { Strings } from "src/utils/Strings";
 
 export async function createFileFromActionIfNotExists(
     filePath: string,
-    action: UpdateFrontmatterFormAction | InsertTextFormAction,
+    action: UpdateFrontmatterFormAction | InsertTextFormAction | MoveFileFormAction,
     context: ActionContext): Promise<TFile> {
     const app = context.app;
     const file = app.vault.getAbstractFileByPath(filePath);
     if (file instanceof TFile) {
         return file;
     }
-
+    if (action.type === FormActionType.MOVE_FILE) {
+        return createFileByText(app, filePath, "");
+    }
     const templateFilePath = action.newFileTemplate;
     let content = "";
     if (Strings.isNotBlank(templateFilePath)) {

--- a/plugin/src/service/action/util/createFileFromActionIfNotExists.ts
+++ b/plugin/src/service/action/util/createFileFromActionIfNotExists.ts
@@ -4,23 +4,19 @@ import { ActionContext } from "../IActionService";
 import { localInstance } from "src/i18n/locals";
 import { InsertTextFormAction } from "src/model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
-import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
-import { FormActionType } from "src/model/enums/FormActionType";
 import { createFileByText } from "src/utils/createFileByText";
 import { Strings } from "src/utils/Strings";
 
 export async function createFileFromActionIfNotExists(
     filePath: string,
-    action: UpdateFrontmatterFormAction | InsertTextFormAction | MoveFileFormAction,
+    action: UpdateFrontmatterFormAction | InsertTextFormAction,
     context: ActionContext): Promise<TFile> {
     const app = context.app;
     const file = app.vault.getAbstractFileByPath(filePath);
     if (file instanceof TFile) {
         return file;
     }
-    if (action.type === FormActionType.MOVE_FILE) {
-        return createFileByText(app, filePath, "");
-    }
+
     const templateFilePath = action.newFileTemplate;
     let content = "";
     if (Strings.isNotBlank(templateFilePath)) {

--- a/plugin/src/service/action/util/getFilePathFromAction.ts
+++ b/plugin/src/service/action/util/getFilePathFromAction.ts
@@ -7,10 +7,11 @@ import { InsertTextFormAction } from "src/model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import { TargetFileType } from "src/model/enums/TargetFileType";
+import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { focusLatestEditor } from "src/utils/focusLatestEditor";
 import { getFilePathCompatible } from "src/utils/getFilePathCompatible";
 
-type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction;
+type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction;
 
 export async function getFilePathFromAction(formAction: Action, context: ActionContext) {
     const app = context.app;
@@ -33,7 +34,7 @@ export async function getFilePathFromAction(formAction: Action, context: ActionC
 
 }
 
-async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction, context: ActionContext) {
+async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction, context: ActionContext) {
     const engine = new FormTemplateProcessEngine();
     const path = getFilePathCompatible(formAction);
     let filePath = await engine.process(path, context.state, context.app);

--- a/plugin/src/service/action/util/getFilePathFromAction.ts
+++ b/plugin/src/service/action/util/getFilePathFromAction.ts
@@ -5,12 +5,13 @@ import { localInstance } from "src/i18n/locals";
 import { CreateFileFormAction } from "src/model/action/CreateFileFormAction";
 import { InsertTextFormAction } from "src/model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
+import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import { TargetFileType } from "src/model/enums/TargetFileType";
 import { focusLatestEditor } from "src/utils/focusLatestEditor";
 import { getFilePathCompatible } from "src/utils/getFilePathCompatible";
 
-type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction;
+type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction;
 
 export async function getFilePathFromAction(formAction: Action, context: ActionContext) {
     const app = context.app;
@@ -33,7 +34,7 @@ export async function getFilePathFromAction(formAction: Action, context: ActionC
 
 }
 
-async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction, context: ActionContext) {
+async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction, context: ActionContext) {
     const engine = new FormTemplateProcessEngine();
     const path = getFilePathCompatible(formAction);
     let filePath = await engine.process(path, context.state, context.app);

--- a/plugin/src/service/action/util/getFilePathFromAction.ts
+++ b/plugin/src/service/action/util/getFilePathFromAction.ts
@@ -7,11 +7,10 @@ import { InsertTextFormAction } from "src/model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import { TargetFileType } from "src/model/enums/TargetFileType";
-import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { focusLatestEditor } from "src/utils/focusLatestEditor";
 import { getFilePathCompatible } from "src/utils/getFilePathCompatible";
 
-type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction;
+type Action = CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction;
 
 export async function getFilePathFromAction(formAction: Action, context: ActionContext) {
     const app = context.app;
@@ -34,7 +33,7 @@ export async function getFilePathFromAction(formAction: Action, context: ActionC
 
 }
 
-async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction | MoveFileFormAction, context: ActionContext) {
+async function resolveFilePath(formAction: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction, context: ActionContext) {
     const engine = new FormTemplateProcessEngine();
     const path = getFilePathCompatible(formAction);
     let filePath = await engine.process(path, context.state, context.app);

--- a/plugin/src/view/edit/setting/action/CpsFormActionDetailSetting.tsx
+++ b/plugin/src/view/edit/setting/action/CpsFormActionDetailSetting.tsx
@@ -9,6 +9,7 @@ import { SuggestModalSetting } from "./suggest-modal/SuggestModalSetting";
 import { UpdateFrontmatterSetting } from "./update-frontmatter/UpdateFrontmatterSetting";
 import { WaitSetting } from "./wait/WaitSetting";
 import { WriteToClipboardSetting } from "./write-to-clipboard/WriteToClipboardSetting";
+import { MoveFileSetting } from "./move-file/MoveFileSetting";
 import { RemarkSetting } from "./common/RemarkSetting";
 import { RunCommandSetting } from "./run-command/RunCommandSetting";
 
@@ -30,6 +31,7 @@ export default function (props: {
 			<GenerateFormSetting value={value} onChange={onChange} />
 			<WaitSetting value={value} onChange={onChange} />
 			<WriteToClipboardSetting value={value} onChange={onChange} />
+			<MoveFileSetting value={value} onChange={onChange} />
 		</CpsForm>
 	);
 }

--- a/plugin/src/view/edit/setting/action/common/ActionTypeSelect.tsx
+++ b/plugin/src/view/edit/setting/action/common/ActionTypeSelect.tsx
@@ -7,6 +7,7 @@ import {
 	Text,
 	ZapIcon,
 	Clipboard,
+	Forward
 } from "lucide-react";
 import { localInstance } from "src/i18n/locals";
 import { FormActionType } from "src/model/enums/FormActionType";
@@ -77,5 +78,10 @@ export const formActionTypeOptions = [
 		value: FormActionType.WRITE_TO_CLIPBOARD,
 		label: localInstance.write_to_clipboard,
 		icon: <Clipboard />,
+	},
+	{
+		value: FormActionType.MOVE_FILE,
+		label: localInstance.move_file,
+		icon: <Forward />,
 	},
 ];

--- a/plugin/src/view/edit/setting/action/common/TargetFileTypeSelect.tsx
+++ b/plugin/src/view/edit/setting/action/common/TargetFileTypeSelect.tsx
@@ -5,10 +5,15 @@ import { TargetFileType } from "src/model/enums/TargetFileType";
 export default function (props: {
 	value: string;
 	onChange: (value: TargetFileType) => void;
+	operationOnFile?: boolean;
 }) {
-	const { value, onChange } = props;
+	const { value, onChange, operationOnFile } = props;
 	return (
-		<RadioSelect
+		operationOnFile?<RadioSelect
+			value={value || TargetFileType.CURRENT_FILE}
+			onChange={onChange}
+			options={moveTargetFileTypeOptions}
+		/>:<RadioSelect
 			value={value || TargetFileType.SPECIFIED_FILE}
 			onChange={onChange}
 			options={insertTargetFileTypeOptions}
@@ -26,5 +31,18 @@ const insertTargetFileTypeOptions = [
 		id: TargetFileType.CURRENT_FILE,
 		value: TargetFileType.CURRENT_FILE,
 		label: localInstance.in_current_file,
+	},
+];
+
+const moveTargetFileTypeOptions = [
+	{
+		id: TargetFileType.SPECIFIED_FILE,
+		value: TargetFileType.SPECIFIED_FILE,
+		label: localInstance.operate_on_specified_file,
+	},
+	{
+		id: TargetFileType.CURRENT_FILE,
+		value: TargetFileType.CURRENT_FILE,
+		label: localInstance.operate_on_current_file,
 	},
 ];

--- a/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
+++ b/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
@@ -2,8 +2,12 @@ import { localInstance } from "src/i18n/locals";
 import { IFormAction } from "src/model/action/IFormAction";
 import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
+import { TargetFileType } from "src/model/enums/TargetFileType";
+import { getFilePathCompatible } from "src/utils/getFilePathCompatible";
+import FolderSuggestInput from "src/component/combobox/FolderSuggestInput";
 import CpsFormItem from "src/view/shared/CpsFormItem";
 import { FilePathFormItem } from "../common/FilePathFormItem";
+import TargetFileTypeSelect from "../common/TargetFileTypeSelect";
 export function MoveFileSetting(props: {
 	value: IFormAction;
 	onChange: (value: IFormAction) => void;
@@ -17,31 +21,45 @@ export function MoveFileSetting(props: {
 	const set = (patch: Partial<MoveFileFormAction>) =>
 		props.onChange({ ...action, ...patch } as IFormAction);
 
+	const targetFilePath = getFilePathCompatible(action);
+
 	return (
 		<>
-			<CpsFormItem label={localInstance.is_current_file}>
-				<input
-					type="checkbox"
-					checked={!!action.isCurrentFile}
-					onChange={(e) => set({ isCurrentFile: e.target.checked })}
+			<CpsFormItem label={localInstance.target_file}>
+				<TargetFileTypeSelect
+					value={action.targetFileType}
+					onChange={(value) => {
+						const newAction = { ...action, targetFileType: value };
+						props.onChange(newAction);
+					}}
 				/>
 			</CpsFormItem>
 
-			{!action.isCurrentFile && (
-				<CpsFormItem label="Source File">
-					<FilePathFormItem
-						label={localInstance.source_file}
-						value={action.file || ""}
-						onChange={(v: string) => set({ file: v })}
-					/>
-				</CpsFormItem>
+			{action.targetFileType === TargetFileType.SPECIFIED_FILE && (
+				<FilePathFormItem
+					label={localInstance.source_file}
+					value={targetFilePath}
+					onChange={(value) => {
+						const newAction = {
+							...action,
+							filePath: value,
+						};
+						props.onChange(newAction);
+					}}
+				/>
 			)}
 
-			<CpsFormItem label="Target Folder">
-				<FilePathFormItem
-					label={localInstance.target_folder}
-					value={action.targetFolder || ""}
-					onChange={(v: string) => set({ targetFolder: v })}
+			<CpsFormItem label={localInstance.target_folder}>
+				<FolderSuggestInput
+					placeholder={localInstance.target_folder}
+					value={action.moveTargetFolder || ""}
+					onChange={(value) => {
+						const newAction = {
+							...action,
+							moveTargetFolder: value,
+						};
+						props.onChange(newAction);
+					}}
 				/>
 			</CpsFormItem>
 		</>

--- a/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
+++ b/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
@@ -4,10 +4,6 @@ import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import CpsFormItem from "src/view/shared/CpsFormItem";
 import { FilePathFormItem } from "../common/FilePathFormItem";
-import TargetFileTypeSelect from "../common/TargetFileTypeSelect";
-import { TargetFileType } from "src/model/enums/TargetFileType";
-import FolderSuggestInput from "src/component/combobox/FolderSuggestInput";
-
 export function MoveFileSetting(props: {
 	value: IFormAction;
 	onChange: (value: IFormAction) => void;
@@ -23,36 +19,28 @@ export function MoveFileSetting(props: {
 
 	return (
 		<>
-			<CpsFormItem label={localInstance.target_file}>
-				<TargetFileTypeSelect
-					value={action.targetFileType}
-					onChange={(value) => {
-						const newAction = { ...action, targetFileType: value };
-						props.onChange(newAction);
-					}}
+			<CpsFormItem label={localInstance.is_current_file}>
+				<input
+					type="checkbox"
+					checked={!!action.isCurrentFile}
+					onChange={(e) => set({ isCurrentFile: e.target.checked })}
 				/>
 			</CpsFormItem>
-			{action.targetFileType === TargetFileType.CURRENT_FILE ? (
-				<></>
-			) : (
-				<>
+
+			{!action.isCurrentFile && (
+				<CpsFormItem label="Source File">
 					<FilePathFormItem
-						label={""}
-						value={action.filePath}
-						onChange={(value) => {
-							const newAction = {
-								...action,
-								filePath: value,
-							};
-							props.onChange(newAction);
-						}}
+						label={localInstance.source_file}
+						value={action.file || ""}
+						onChange={(v: string) => set({ file: v })}
 					/>
-				</>
+				</CpsFormItem>
 			)}
 
-			<CpsFormItem label={localInstance.target_folder}>
-				<FolderSuggestInput
-					value={action.targetFolder}
+			<CpsFormItem label="Target Folder">
+				<FilePathFormItem
+					label={localInstance.target_folder}
+					value={action.targetFolder || ""}
 					onChange={(v: string) => set({ targetFolder: v })}
 				/>
 			</CpsFormItem>

--- a/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
+++ b/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
@@ -25,19 +25,20 @@ export function MoveFileSetting(props: {
 
 	return (
 		<>
-			<CpsFormItem label={localInstance.target_file}>
+			<CpsFormItem label={localInstance.operation_object}>
 				<TargetFileTypeSelect
 					value={action.targetFileType}
 					onChange={(value) => {
 						const newAction = { ...action, targetFileType: value };
 						props.onChange(newAction);
 					}}
+					operationOnFile={true}
 				/>
 			</CpsFormItem>
 
 			{action.targetFileType === TargetFileType.SPECIFIED_FILE && (
 				<FilePathFormItem
-					label={localInstance.source_file}
+					label= ''
 					value={targetFilePath}
 					onChange={(value) => {
 						const newAction = {

--- a/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
+++ b/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
@@ -1,0 +1,49 @@
+import { localInstance } from "src/i18n/locals";
+import { IFormAction } from "src/model/action/IFormAction";
+import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
+import { FormActionType } from "src/model/enums/FormActionType";
+import CpsFormItem from "src/view/shared/CpsFormItem";
+import { FilePathFormItem } from "../common/FilePathFormItem";
+export function MoveFileSetting(props: {
+	value: IFormAction;
+	onChange: (value: IFormAction) => void;
+}) {
+	const { value } = props;
+	if (value.type !== FormActionType.MOVE_FILE) {
+		return null;
+	}
+	const action = value as MoveFileFormAction;
+
+	const set = (patch: Partial<MoveFileFormAction>) =>
+		props.onChange({ ...action, ...patch } as IFormAction);
+
+	return (
+		<>
+			<CpsFormItem label={localInstance.is_current_file}>
+				<input
+					type="checkbox"
+					checked={!!action.isCurrentFile}
+					onChange={(e) => set({ isCurrentFile: e.target.checked })}
+				/>
+			</CpsFormItem>
+
+			{!action.isCurrentFile && (
+				<CpsFormItem label="Source File">
+					<FilePathFormItem
+						label={localInstance.source_file}
+						value={action.file || ""}
+						onChange={(v: string) => set({ file: v })}
+					/>
+				</CpsFormItem>
+			)}
+
+			<CpsFormItem label="Target Folder">
+				<FilePathFormItem
+					label={localInstance.target_folder}
+					value={action.targetFolder || ""}
+					onChange={(v: string) => set({ targetFolder: v })}
+				/>
+			</CpsFormItem>
+		</>
+	);
+}

--- a/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
+++ b/plugin/src/view/edit/setting/action/move-file/MoveFileSetting.tsx
@@ -4,6 +4,10 @@ import { MoveFileFormAction } from "src/model/action/MoveFileFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
 import CpsFormItem from "src/view/shared/CpsFormItem";
 import { FilePathFormItem } from "../common/FilePathFormItem";
+import TargetFileTypeSelect from "../common/TargetFileTypeSelect";
+import { TargetFileType } from "src/model/enums/TargetFileType";
+import FolderSuggestInput from "src/component/combobox/FolderSuggestInput";
+
 export function MoveFileSetting(props: {
 	value: IFormAction;
 	onChange: (value: IFormAction) => void;
@@ -19,28 +23,36 @@ export function MoveFileSetting(props: {
 
 	return (
 		<>
-			<CpsFormItem label={localInstance.is_current_file}>
-				<input
-					type="checkbox"
-					checked={!!action.isCurrentFile}
-					onChange={(e) => set({ isCurrentFile: e.target.checked })}
+			<CpsFormItem label={localInstance.target_file}>
+				<TargetFileTypeSelect
+					value={action.targetFileType}
+					onChange={(value) => {
+						const newAction = { ...action, targetFileType: value };
+						props.onChange(newAction);
+					}}
 				/>
 			</CpsFormItem>
-
-			{!action.isCurrentFile && (
-				<CpsFormItem label="Source File">
+			{action.targetFileType === TargetFileType.CURRENT_FILE ? (
+				<></>
+			) : (
+				<>
 					<FilePathFormItem
-						label={localInstance.source_file}
-						value={action.file || ""}
-						onChange={(v: string) => set({ file: v })}
+						label={""}
+						value={action.filePath}
+						onChange={(value) => {
+							const newAction = {
+								...action,
+								filePath: value,
+							};
+							props.onChange(newAction);
+						}}
 					/>
-				</CpsFormItem>
+				</>
 			)}
 
-			<CpsFormItem label="Target Folder">
-				<FilePathFormItem
-					label={localInstance.target_folder}
-					value={action.targetFolder || ""}
+			<CpsFormItem label={localInstance.target_folder}>
+				<FolderSuggestInput
+					value={action.targetFolder}
 					onChange={(v: string) => set({ targetFolder: v })}
 				/>
 			</CpsFormItem>


### PR DESCRIPTION
Add a new MoveFile form action:
- Register the new action in FormActionFactory and IActionService
    registry so it can be created and executed.
- Add UI bits: ActionTypeSelect option, WriteToClipboardSetting
    inclusion in action settings, and corresponding import fixes.
    Add i18n keys for English, Chinese and local type string.
- use obsiidan app.fileManager.renameFile to move file, and it will 
    be failed if the target folder has a file whose name
    is the same with source file 
This enables creating actions that move current file, specific file or 
form flow variable {{@ variable }}.

close #85 
