### PR TITLE
feat: add property update operations

### DIFF
--- a/plugin/src/hooks/useActionValidation.ts
+++ b/plugin/src/hooks/useActionValidation.ts
@@ -1,4 +1,5 @@
 import { getLanguage } from "obsidian";
+import { PropertyUpdateOperation } from "src/model/enums/PropertyUpdateOperation";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
 import { CreateFileFormAction } from "../model/action/CreateFileFormAction";
 import { IFormAction } from "../model/action/IFormAction";
@@ -103,7 +104,11 @@ function validateAction(action: FormActionImp) {
                 messages.push(l.properties_must_not_be_empty);
             } else {
                 const hasInvalidUpdate = propertyUpdates.some(
-                    update => !update.name || update.value === undefined
+                    update => {
+                        if (!update.name) return true;
+                        if (update.operation === PropertyUpdateOperation.REMOVE) return false;
+                        return update.value === undefined;
+                    }
                 );
                 if (hasInvalidUpdate) {
                     messages.push(l.property_configure_incompleted);

--- a/plugin/src/i18n/en.ts
+++ b/plugin/src/i18n/en.ts
@@ -159,6 +159,10 @@ export class En implements Local {
 	property_name = "Property name";
 	property_value = "Property value";
 	property_value_suggestions = "Property value suggestions";
+	property_operation_set = "Overwrite";
+	property_operation_add = "Append";
+	property_operation_remove = "Remove";
+	property_update_operation = "Update operation";
 	register_as_command = "Register as command";
 	register_as_command_description = "After registration, you can assign a shortcut to open the form";
 	remove_value = "Remove value";

--- a/plugin/src/i18n/local.ts
+++ b/plugin/src/i18n/local.ts
@@ -151,6 +151,10 @@ export interface Local {
 	property_name: string;
 	property_value_suggestions: string;
 	property_value: string;
+	property_operation_set: string;
+	property_operation_add: string;
+	property_operation_remove: string;
+	property_update_operation: string;
 	property: string;
 	register_as_command_description: string;
 	register_as_command: string;

--- a/plugin/src/i18n/zh.ts
+++ b/plugin/src/i18n/zh.ts
@@ -159,6 +159,10 @@ export class Zh implements Local {
 	property_name = "属性名";
 	property_value = "属性值";
 	property_value_suggestions = "属性值列表";
+	property_operation_set = "覆盖";
+	property_operation_add = "追加";
+	property_operation_remove = "删除";
+	property_update_operation = "更新方式";
 	register_as_command = "注册为命令";
 	register_as_command_description = "注册为命令后可以设置快捷键打开表单";
 	remove_value = "删除值";

--- a/plugin/src/i18n/zhTw.ts
+++ b/plugin/src/i18n/zhTw.ts
@@ -159,6 +159,10 @@ export class ZhTw implements Local {
 	property_name = "屬性名";
 	property_value = "屬性值";
 	property_value_suggestions = "屬性值列表";
+	property_operation_set = "覆蓋";
+	property_operation_add = "追加";
+	property_operation_remove = "刪除";
+	property_update_operation = "更新方式";
 	register_as_command = "註冊為命令";
 	register_as_command_description = "註冊為命令後可以設置快捷鍵打開表單";
 	remove_value = "刪除值";

--- a/plugin/src/model/action/UpdateFrontmatterFormAction.ts
+++ b/plugin/src/model/action/UpdateFrontmatterFormAction.ts
@@ -1,4 +1,5 @@
 import { FormActionType } from "../enums/FormActionType";
+import { PropertyUpdateOperation } from "../enums/PropertyUpdateOperation";
 import { TargetFileType } from "../enums/TargetFileType";
 import { FileBaseFormAction } from "./FileBaseFormAction";
 
@@ -26,4 +27,5 @@ export interface PropertyUpdate {
     id: string;
     name: string;
     value: any;
+    operation: PropertyUpdateOperation;
 }

--- a/plugin/src/model/enums/PropertyUpdateOperation.ts
+++ b/plugin/src/model/enums/PropertyUpdateOperation.ts
@@ -1,0 +1,5 @@
+export enum PropertyUpdateOperation {
+    SET = "set",
+    ADD = "add",
+    REMOVE = "remove"
+}

--- a/plugin/src/service/action/update-frontmatter/UpdateFrontmatterActionService.ts
+++ b/plugin/src/service/action/update-frontmatter/UpdateFrontmatterActionService.ts
@@ -1,6 +1,7 @@
 import { IFormAction } from "src/model/action/IFormAction";
 import { UpdateFrontmatterFormAction } from "src/model/action/UpdateFrontmatterFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
+import { PropertyUpdateOperation } from "src/model/enums/PropertyUpdateOperation";
 import { FormTemplateProcessEngine } from "src/service/engine/FormTemplateProcessEngine";
 import { convertFrontmatterValue } from "src/utils/convertFrontmatterValue";
 import { IActionService, ActionContext, ActionChain } from "../IActionService";
@@ -23,6 +24,7 @@ export default class UpdateFrontmatterActionService implements IActionService {
         const formatted: {
             name: string;
             value: string | string[];
+            operation: PropertyUpdateOperation;
         }[] = []
         for (const property of action.propertyUpdates) {
             const name = await engien.process(property.name, context.state, app);
@@ -43,13 +45,33 @@ export default class UpdateFrontmatterActionService implements IActionService {
             formatted.push({
                 name: name,
                 value: value,
+                operation: property.operation || PropertyUpdateOperation.SET,
             })
         }
         const filePath = await getFilePathFromAction(action, context);
         const file = await createFileFromActionIfNotExists(filePath, action, context);
         await app.fileManager.processFrontMatter(file, (frontmatter) => {
             for (const property of formatted) {
-                frontmatter[property.name] = convertFrontmatterValue(app, property.name, property.value);
+                const convertedValue = convertFrontmatterValue(app, property.name, property.value);
+                switch (property.operation) {
+                    case PropertyUpdateOperation.ADD:
+                        if (Array.isArray(frontmatter[property.name])) {
+                            const existing = frontmatter[property.name] as any[];
+                            const toAdd = Array.isArray(convertedValue) ? convertedValue : [convertedValue];
+                            const merged = [...new Set([...existing, ...toAdd])];
+                            frontmatter[property.name] = convertFrontmatterValue(app, property.name, merged);
+                        } else if (frontmatter[property.name] === undefined || frontmatter[property.name] === null) {
+                            frontmatter[property.name] = convertedValue;
+                        }
+                        break;
+                    case PropertyUpdateOperation.REMOVE:
+                        delete frontmatter[property.name];
+                        break;
+                    case PropertyUpdateOperation.SET:
+                    default:
+                        frontmatter[property.name] = convertedValue;
+                        break;
+                }
             }
         });
         return await chain.next(context);

--- a/plugin/src/utils/getActionSummary.ts
+++ b/plugin/src/utils/getActionSummary.ts
@@ -3,6 +3,7 @@ import { CreateFileFormAction } from "../model/action/CreateFileFormAction";
 import { InsertTextFormAction } from "../model/action/InsertTextFormAction";
 import { UpdateFrontmatterFormAction } from "../model/action/UpdateFrontmatterFormAction";
 import { FormActionType } from "../model/enums/FormActionType";
+import { PropertyUpdateOperation } from "../model/enums/PropertyUpdateOperation";
 import { TargetFileType } from "../model/enums/TargetFileType";
 
 export function getActionSummary(action: CreateFileFormAction | InsertTextFormAction | UpdateFrontmatterFormAction): Array<{ label: string; value: string }> {
@@ -62,7 +63,16 @@ export function getActionSummary(action: CreateFileFormAction | InsertTextFormAc
 
             const propertyUpdates = action.propertyUpdates || [];
             if (propertyUpdates.length > 0) {
-                const propertiesList = propertyUpdates.map(update => update.name).join(', ');
+                const propertiesList = propertyUpdates.map(update => {
+                    const operation = update.operation || PropertyUpdateOperation.SET;
+                    if (operation === PropertyUpdateOperation.SET) {
+                        return update.name;
+                    }
+                    const opLabel = operation === PropertyUpdateOperation.ADD
+                        ? localInstance.property_operation_add
+                        : localInstance.property_operation_remove;
+                    return `${update.name}[${opLabel}]`;
+                }).join(', ');
                 summary.push({
                     label: localInstance.property,
                     value: propertiesList

--- a/plugin/src/view/edit/setting/action/update-frontmatter/PropertyUpdateOperationSelect.tsx
+++ b/plugin/src/view/edit/setting/action/update-frontmatter/PropertyUpdateOperationSelect.tsx
@@ -1,0 +1,32 @@
+import { Select2 } from "src/component/select2/Select";
+import { localInstance } from "src/i18n/locals";
+import { PropertyUpdateOperation } from "src/model/enums/PropertyUpdateOperation";
+
+export default function (props: {
+	value: string;
+	onChange: (value: PropertyUpdateOperation) => void;
+}) {
+	const { value, onChange } = props;
+	return (
+		<Select2
+			value={value || PropertyUpdateOperation.SET}
+			onChange={onChange}
+			options={options}
+		/>
+	);
+}
+
+const options = [
+	{
+		value: PropertyUpdateOperation.SET,
+		label: localInstance.property_operation_set,
+	},
+	{
+		value: PropertyUpdateOperation.ADD,
+		label: localInstance.property_operation_add,
+	},
+	{
+		value: PropertyUpdateOperation.REMOVE,
+		label: localInstance.property_operation_remove,
+	},
+];

--- a/plugin/src/view/edit/setting/action/update-frontmatter/PropertyUpdateValueInput.tsx
+++ b/plugin/src/view/edit/setting/action/update-frontmatter/PropertyUpdateValueInput.tsx
@@ -12,10 +12,11 @@ type Props = {
 	value: any;
 	onChange: (value: any) => void;
 	placeholder?: string;
+	hidden?: boolean;
 };
 
 export function PropertyUpdateValueInput(props: Props) {
-	const { name, value, onChange, actionId } = props;
+	const { name, value, onChange, actionId, hidden } = props;
 	const formConfig = useFormConfig();
 	const variables = useVariables(actionId, formConfig);
 	const app = useObsidianApp();
@@ -27,6 +28,10 @@ export function PropertyUpdateValueInput(props: Props) {
 			description: v.info,
 		};
 	});
+
+	if (hidden) {
+		return null;
+	}
 
 	if (isMultiple) {
 		let arrayValue;

--- a/plugin/src/view/edit/setting/action/update-frontmatter/UpdateFrontmatterSetting.tsx
+++ b/plugin/src/view/edit/setting/action/update-frontmatter/UpdateFrontmatterSetting.tsx
@@ -6,6 +6,7 @@ import {
 	PropertyUpdate,
 } from "src/model/action/UpdateFrontmatterFormAction";
 import { FormActionType } from "src/model/enums/FormActionType";
+import { PropertyUpdateOperation } from "src/model/enums/PropertyUpdateOperation";
 import { TargetFileType } from "src/model/enums/TargetFileType";
 import { getFilePathCompatible } from "src/utils/getFilePathCompatible";
 import CpsFormItem from "src/view/shared/CpsFormItem";
@@ -16,6 +17,7 @@ import {
 import { v4 } from "uuid";
 import { FilePathFormItem } from "../common/FilePathFormItem";
 import TargetFileTypeSelect from "../common/TargetFileTypeSelect";
+import PropertyUpdateOperationSelect from "./PropertyUpdateOperationSelect";
 import { PropertyUpdateValueInput } from "./PropertyUpdateValueInput";
 import { PropertyNameSuggestInput } from "src/component/combobox/PropertyNameSuggestInput";
 
@@ -83,6 +85,7 @@ export function UpdateFrontmatterSetting(props: {
 						id: v4(),
 						name: "",
 						value: "",
+						operation: PropertyUpdateOperation.SET,
 					};
 					const newItems = [...items, newItem];
 					const newAction = {
@@ -130,9 +133,20 @@ export function UpdateFrontmatterSetting(props: {
 										};
 										saveItem(newItem);
 									}}
+									hidden={item.operation === PropertyUpdateOperation.REMOVE}
 								/>
 							</div>
 							<div className="form--InteractiveListItemActions">
+								<PropertyUpdateOperationSelect
+									value={item.operation || PropertyUpdateOperation.SET}
+									onChange={(value) => {
+										const newItem = {
+											...item,
+											operation: value,
+										};
+										saveItem(newItem);
+									}}
+								/>
 								<button
 									className="clickable-icon"
 									data-type="danger"


### PR DESCRIPTION
closed #110 

## 变更说明

此前「更新属性」动作只能覆盖属性值，无法灵活应对追加或删除属性的场景。本次改动为每个属性配置项增加了操作方式下拉选择，支持三种模式：

| 操作 | 行为 |
|------|------|
| **覆盖** | 用新值覆盖原属性值（原有行为） |
| **追加** | 保留原值。数组属性合并去重；非数组属性仅在不存时赋值，已有值则不覆盖 |
| **删除** | 删除整个属性，属性不存在时跳过 |

## 改动文件

- 新增 `PropertyUpdateOperation` 枚举和 `PropertyUpdateOperationSelect` 下拉组件
- `PropertyUpdate` 接口增加 `operation` 字段（默认 `SET`，向后兼容）
- `UpdateFrontmatterActionService` 按操作类型分支执行
- 校验逻辑：`REMOVE` 操作不要求填写属性值
- UI：「删除」操作时自动隐藏属性值输入框
- i18n：中/英/繁体三语翻译
- 动作摘要中标注非默认操作类型