### PR TITLE
feat: support multi-line field descriptions

### DIFF
--- a/plugin/src/view/edit/setting/action/CpsFormAction.css
+++ b/plugin/src/view/edit/setting/action/CpsFormAction.css
@@ -20,7 +20,8 @@
 
 @media (any-hover: hover) {
 	.form--CpsFormActionSetting:hover {
-		box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
+		box-shadow:
+			rgba(0, 0, 0, 0.1) 0px 4px 6px -1px,
 			rgba(0, 0, 0, 0.06) 0px 2px 4px -1px;
 	}
 }
@@ -111,11 +112,13 @@ button.form-CpsFormActinoCodeResetButton:hover {
 	flex-grow: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	white-space: nowrap;
+	white-space: normal;
 	padding-inline-start: 8px;
 	font-size: var(--font-ui-small);
 	color: var(--text-muted);
 	font-style: italic;
+	word-break: break-all;
+	overflow-wrap: break-word;
 }
 
 .form--CpsFormActionBottomSection {

--- a/plugin/src/view/edit/setting/field/setting-content/description/DescriptionSetting.css
+++ b/plugin/src/view/edit/setting/field/setting-content/description/DescriptionSetting.css
@@ -1,17 +1,10 @@
 .form--CpsFormFieldSettingDescription {
 	width: 100%;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 }
 
-@media (any-hover: hover) {
-	.form--CpsFormFieldSettingDescription:hover {
-		background-color: var(--background-modifier-hover);
-	}
-}
-
-.form--CpsFormFieldSettingDescription input[type="text"] {
-	all: unset;
+.form--CpsFormFieldSettingDescription textarea {
 	width: 100%;
 	color: var(--text-faint);
 	font-size: var(--font-ui-smaller);
@@ -19,9 +12,13 @@
 	padding: 4px 12px;
 	flex-grow: 1;
 	border-radius: var(--radius-m);
+	border: none;
+	background: transparent;
+	resize: vertical;
+	font-family: inherit;
 }
 
-.form--CpsFormFieldSettingDescription input[type="text"]:focus {
+.form--CpsFormFieldSettingDescription textarea:focus {
 	outline: none;
 	background-color: var(--color-base-10);
 }

--- a/plugin/src/view/edit/setting/field/setting-content/description/DescriptionSetting.tsx
+++ b/plugin/src/view/edit/setting/field/setting-content/description/DescriptionSetting.tsx
@@ -9,8 +9,8 @@ export function DescriptionSetting(props: {
 	const { field, onChange } = props;
 	return (
 		<div className="form--CpsFormFieldSettingDescription">
-			<input
-				type="text"
+			<textarea
+				rows={4}
 				value={field.description || ""}
 				placeholder={localInstance.input_description_here}
 				onChange={(e) => {

--- a/plugin/src/view/shared/CpsFormItem.css
+++ b/plugin/src/view/shared/CpsFormItem.css
@@ -15,6 +15,8 @@
 	margin-bottom: 0.5rem;
 	margin-top: 0.5rem;
 	white-space: pre-wrap;
+	word-break: break-all;
+	overflow-wrap: break-word;
 }
 
 /* required * */

--- a/plugin/src/view/shared/CpsFormItem.css
+++ b/plugin/src/view/shared/CpsFormItem.css
@@ -14,6 +14,7 @@
 	line-height: var(--line-height-tight);
 	margin-bottom: 0.5rem;
 	margin-top: 0.5rem;
+	white-space: pre-wrap;
 }
 
 /* required * */


### PR DESCRIPTION
closed #111

## 变更说明

### 1. 字段描述支持多行输入

描述输入框由单行 `<input>` 改为 `<textarea>`，支持换行和多行文本编辑，默认 2 行高度。

### 2. 长文本溢出修复

- 表单字段描述（`form--CpsFormItemInfoDescription`）：添加 `white-space: pre-wrap`、`word-break: break-all`、`overflow-wrap: break-word`，长文本自动换行不再溢出容器
- 动作备注文本（`form--CpsFormActionRemarkText`）：`white-space: nowrap` 改为 `white-space: normal`，并添加相同的断词规则

## 改动文件

- `DescriptionSetting.tsx`：`<input>` → `<textarea rows={2}>`
- `DescriptionSetting.css`：适配 textarea 样式
- `CpsFormItem.css`：描述文本添加换行和断词规则
- `CpsFormAction.css`：备注文本修复溢出